### PR TITLE
Make sheet URL configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,12 @@ El resultado se exporta automáticamente a tu Google Sheet:
 2. Autenticá tu cuenta de Google.
 3. Indicá la URL de tu Google Sheet. Podés definir la variable de entorno
    `SHEET_URL` antes de ejecutar el script o ingresarla manualmente cuando se
-   te solicite.
+   te solicite. Si querés fijarla de antemano, ejecutá en una celda:
+
+   ```python
+   import os
+   os.environ["SHEET_URL"] = "https://mi-sheet.google.com/..."
+   ```
 4. Ejecutá todas las celdas.
 5. Revisá la hoja `Distribución python` con los resultados y el resumen.
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ El resultado se exporta automáticamente a tu Google Sheet:
 
 1. Abrí el notebook en Google Colab.
 2. Autenticá tu cuenta de Google.
-3. Verificá que el enlace al Google Sheet sea correcto.
+3. Indicá la URL de tu Google Sheet. Podés definir la variable de entorno
+   `SHEET_URL` antes de ejecutar el script o ingresarla manualmente cuando se
+   te solicite.
 4. Ejecutá todas las celdas.
 5. Revisá la hoja `Distribución python` con los resultados y el resumen.
 

--- a/Script_Gen
+++ b/Script_Gen
@@ -5,6 +5,7 @@
 import gspread
 from google.colab import auth
 from google.auth import default
+import os
 import pandas as pd
 import math
 import copy
@@ -17,7 +18,9 @@ creds, _ = default()
 gc = gspread.authorize(creds)
 
 # 📄 ABRIR PLANILLA
-sheet_url = "https://docs.google.com/spreadsheets/d/1uCuEVqUVc9ofHrpgzF2jq4jDIWr-kF33MxtZQLi0CCQ"
+sheet_url = os.environ.get("SHEET_URL")
+if not sheet_url:
+    sheet_url = input("🔗 Ingresá la URL del Google Sheet: ").strip()
 spreadsheet = gc.open_by_url(sheet_url)
 hoja_escuelas = spreadsheet.worksheet("Estudiantes acreditados")
 hoja_grupos = spreadsheet.worksheet("Asignación de Elementos y Coordinadores")


### PR DESCRIPTION
## Summary
- add `os` import
- prompt for the Google Sheet URL using `SHEET_URL` env var or manual input
- document how to specify the sheet URL before running

## Testing
- `python3 -m py_compile Script_Gen` *(fails: invalid syntax due to Colab directives)*

------
https://chatgpt.com/codex/tasks/task_b_6885acae5fac832193491e64d14dc118